### PR TITLE
Add brand and product logos across site

### DIFF
--- a/assets/flowcrm-logo.svg
+++ b/assets/flowcrm-logo.svg
@@ -1,0 +1,18 @@
+<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="flowcrmGradient" x1="16" y1="12" x2="58" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#312E81"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="flowcrmRibbon" x1="20" y1="20" x2="56" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#60A5FA"/>
+      <stop offset="0.5" stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#14B8A6"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="60" height="60" rx="18" fill="url(#flowcrmGradient)"/>
+  <path d="M22 30C22 24.477 26.477 20 32 20H40C44.4183 20 48 23.5817 48 28V32C48 37.5228 43.5228 42 38 42H36C30.4772 42 26 46.4772 26 52V52" stroke="url(#flowcrmRibbon)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M28 52C28 46.4772 32.4772 42 38 42H40C45.5228 42 50 37.5228 50 32V24" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  <circle cx="48" cy="24" r="4" fill="#F1F5F9"/>
+  <circle cx="26" cy="52" r="5" fill="#22D3EE"/>
+</svg>

--- a/assets/stoxedge-logo.svg
+++ b/assets/stoxedge-logo.svg
@@ -1,0 +1,18 @@
+<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stoxedgeGradient" x1="18" y1="12" x2="54" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#22C55E"/>
+    </linearGradient>
+    <linearGradient id="stoxedgeGlow" x1="28" y1="20" x2="50" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#BEF264" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="60" height="60" rx="20" fill="#0F172A" opacity="0.85"/>
+  <circle cx="36" cy="36" r="26" fill="url(#stoxedgeGradient)"/>
+  <circle cx="36" cy="36" r="18" fill="url(#stoxedgeGlow)"/>
+  <path d="M22 39L30.5 31.5L34 36L41.5 28.5L50 37" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M22 44C22 44 27 44 30 44C34 44 39 42 44 38C47 36 50 33 50 33" stroke="#E2F7FF" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.8"/>
+  <circle cx="50" cy="37" r="4" fill="#F8FAFC"/>
+</svg>

--- a/assets/suvixit-logo.svg
+++ b/assets/suvixit-logo.svg
@@ -1,0 +1,16 @@
+<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="suvixitGradient" x1="12" y1="10" x2="60" y2="62" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#3B6CFF"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+    <linearGradient id="suvixitGlow" x1="20" y1="18" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="60" height="60" rx="18" fill="url(#suvixitGradient)"/>
+  <rect x="12" y="12" width="48" height="48" rx="15" fill="url(#suvixitGlow)" opacity="0.25"/>
+  <path d="M48 20H30C24.477 20 20 23.686 20 28.5C20 33.314 24.477 37 30 37H40C45.523 37 50 40.686 50 45.5C50 50.314 45.523 54 40 54H24" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="48" cy="24" r="4" fill="#F8FAFC"/>
+</svg>

--- a/flowcrm.html
+++ b/flowcrm.html
@@ -32,11 +32,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex h-16 items-center justify-between">
         <a href="index.html" class="flex items-center gap-3 group">
-          <div class="relative w-9 h-9 grid place-items-center rounded-xl bg-gradient-to-br from-primary-500 to-indigo-600 text-white shadow-soft">
-            <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M4 16l8-12 8 12-8 4-8-4z"/>
-            </svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9 drop-shadow-[0_8px_16px_rgba(59,108,255,0.35)]" decoding="async" />
           <div class="leading-tight">
             <div class="font-extrabold tracking-tight text-lg">Suvix IT</div>
             <div class="text-xs text-slate-500 dark:text-slate-400">Keep IT Simple</div>
@@ -75,6 +71,7 @@
       <nav class="text-sm text-slate-500"><a href="index.html" class="hover:underline">Home</a> / <span class="text-slate-700 dark:text-slate-300">FlowCRM</span></nav>
       <div class="mt-4 grid lg:grid-cols-2 gap-8 items-center">
         <div>
+          <img src="assets/flowcrm-logo.svg" alt="FlowCRM logo" class="w-16 h-16 mb-4" decoding="async" />
           <h1 class="text-4xl font-extrabold tracking-tight">FlowCRM</h1>
           <p class="mt-3 text-lg text-slate-600 dark:text-slate-300">A zero‑clutter CRM for leads, deals, and team activities—so your pipeline stays in flow.</p>
           <div class="mt-6 flex gap-3">
@@ -132,9 +129,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
         <div class="flex items-center gap-3">
-          <div class="w-8 h-8 grid place-items-center rounded-lg bg-gradient-to-br from-primary-600 to-indigo-600 text-white">
-            <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 16l8-12 8 12-8 4-8-4z"/></svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9" decoding="async" />
           <div>
             <div class="font-bold">Suvix IT</div>
             <div class="text-xs text-slate-500">© <span id="y"></span> All rights reserved.</div>

--- a/index.html
+++ b/index.html
@@ -32,11 +32,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex h-16 items-center justify-between">
         <a href="index.html" class="flex items-center gap-3 group">
-          <div class="relative w-9 h-9 grid place-items-center rounded-xl bg-gradient-to-br from-primary-500 to-indigo-600 text-white shadow-soft">
-            <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M4 16l8-12 8 12-8 4-8-4z"/>
-            </svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9 drop-shadow-[0_8px_16px_rgba(59,108,255,0.35)]" decoding="async" />
           <div class="leading-tight">
             <div class="font-extrabold tracking-tight text-lg">Suvix IT</div>
             <div class="text-xs text-slate-500 dark:text-slate-400">Keep IT Simple</div>
@@ -95,11 +91,13 @@
           <div class="aspect-[16/10] rounded-2xl border border-slate-200 dark:border-white/10 shadow-soft bg-gradient-to-br from-white to-slate-50 dark:from-slate-900 dark:to-slate-800 p-4">
             <div class="grid grid-cols-2 gap-4 h-full">
               <a href="stoxedge.html" class="rounded-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/70 dark:border-white/10 p-4 flex flex-col hover:ring-2 hover:ring-primary-500">
+                <img src="assets/stoxedge-logo.svg" alt="StoxEdge logo" class="w-10 h-10 mb-3" loading="lazy" decoding="async" />
                 <div class="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">StoxEdge</div>
                 <div class="mt-1 font-semibold">Day-trade Insights</div>
                 <div class="mt-auto text-sm text-slate-600 dark:text-slate-300">Real-time signals, watchlists & risk cues for NSE & BSE.*</div>
               </a>
               <a href="flowcrm.html" class="rounded-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/70 dark:border-white/10 p-4 flex flex-col hover:ring-2 hover:ring-primary-500">
+                <img src="assets/flowcrm-logo.svg" alt="FlowCRM logo" class="w-10 h-10 mb-3" loading="lazy" decoding="async" />
                 <div class="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">FlowCRM</div>
                 <div class="mt-1 font-semibold">Your Pipeline, in Flow</div>
                 <div class="mt-auto text-sm text-slate-600 dark:text-slate-300">Leads, deals, tasks & email sync—zero clutter.</div>
@@ -123,8 +121,11 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div class="group rounded-2xl border border-slate-200 dark:border-white/10 p-6 bg-white dark:bg-slate-900 shadow-soft hover:-translate-y-0.5 transition-transform">
-          <div class="flex items-center justify-between">
-            <h3 class="text-2xl font-bold">StoxEdge <span class="text-sm font-medium text-slate-500 dark:text-slate-400 align-middle">for Traders</span></h3>
+          <div class="flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <img src="assets/stoxedge-logo.svg" alt="StoxEdge logo" class="w-12 h-12 shrink-0" loading="lazy" decoding="async" />
+              <h3 class="text-2xl font-bold">StoxEdge <span class="text-sm font-medium text-slate-500 dark:text-slate-400 align-middle">for Traders</span></h3>
+            </div>
             <span class="text-xs rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 px-2 py-1">New</span>
           </div>
           <p class="mt-3 text-slate-600 dark:text-slate-300">Intraday signals, heatmaps, and risk controls for NSE/BSE day traders in India.</p>
@@ -134,8 +135,11 @@
           </div>
         </div>
         <div class="group rounded-2xl border border-slate-200 dark:border-white/10 p-6 bg-white dark:bg-slate-900 shadow-soft hover:-translate-y-0.5 transition-transform">
-          <div class="flex items-center justify-between">
-            <h3 class="text-2xl font-bold">FlowCRM <span class="text-sm font-medium text-slate-500 dark:text-slate-400 align-middle">for Teams</span></h3>
+          <div class="flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <img src="assets/flowcrm-logo.svg" alt="FlowCRM logo" class="w-12 h-12 shrink-0" loading="lazy" decoding="async" />
+              <h3 class="text-2xl font-bold">FlowCRM <span class="text-sm font-medium text-slate-500 dark:text-slate-400 align-middle">for Teams</span></h3>
+            </div>
             <span class="text-xs rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 px-2 py-1">Popular</span>
           </div>
           <p class="mt-3 text-slate-600 dark:text-slate-300">Zero-clutter CRM to track leads, deals, and activities—so your team stays in flow.</p>
@@ -214,9 +218,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
         <div class="flex items-center gap-3">
-          <div class="w-8 h-8 grid place-items-center rounded-lg bg-gradient-to-br from-primary-600 to-indigo-600 text-white">
-            <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 16l8-12 8 12-8 4-8-4z"/></svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9" decoding="async" />
           <div>
             <div class="font-bold">Suvix IT</div>
             <div class="text-xs text-slate-500">© <span id="y"></span> All rights reserved.</div>

--- a/stoxedge.html
+++ b/stoxedge.html
@@ -32,11 +32,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex h-16 items-center justify-between">
         <a href="index.html" class="flex items-center gap-3 group">
-          <div class="relative w-9 h-9 grid place-items-center rounded-xl bg-gradient-to-br from-primary-500 to-indigo-600 text-white shadow-soft">
-            <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M4 16l8-12 8 12-8 4-8-4z"/>
-            </svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9 drop-shadow-[0_8px_16px_rgba(59,108,255,0.35)]" decoding="async" />
           <div class="leading-tight">
             <div class="font-extrabold tracking-tight text-lg">Suvix IT</div>
             <div class="text-xs text-slate-500 dark:text-slate-400">Keep IT Simple</div>
@@ -75,6 +71,7 @@
       <nav class="text-sm text-slate-500"><a href="index.html" class="hover:underline">Home</a> / <span class="text-slate-700 dark:text-slate-300">StoxEdge</span></nav>
       <div class="mt-4 grid lg:grid-cols-2 gap-8 items-center">
         <div>
+          <img src="assets/stoxedge-logo.svg" alt="StoxEdge logo" class="w-16 h-16 mb-4" decoding="async" />
           <h1 class="text-4xl font-extrabold tracking-tight">StoxEdge</h1>
           <p class="mt-3 text-lg text-slate-600 dark:text-slate-300">Intraday signals, heatmaps, and risk controls designed for Indian day traders.</p>
           <div class="mt-6 flex gap-3">
@@ -133,9 +130,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
         <div class="flex items-center gap-3">
-          <div class="w-8 h-8 grid place-items-center rounded-lg bg-gradient-to-br from-primary-600 to-indigo-600 text-white">
-            <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 16l8-12 8 12-8 4-8-4z"/></svg>
-          </div>
+          <img src="assets/suvixit-logo.svg" alt="Suvix IT logo" class="w-9 h-9" decoding="async" />
           <div>
             <div class="font-bold">Suvix IT</div>
             <div class="text-xs text-slate-500">© <span id="y"></span> All rights reserved.</div>


### PR DESCRIPTION
## Summary
- add dedicated SVG logos for Suvix IT, StoxEdge, and FlowCRM
- update navigation, hero, product cards, and footers to surface the new branding across all pages

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d22037b8ac83318da90b07032405fe