### PR TITLE
Add careers page with ASP.NET Core and React openings

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <title>Careers at Suvix IT — Build Modern Products Together</title>
+  <meta name="description" content="Explore engineering openings at Suvix IT. We're hiring ASP.NET Core and React developers across junior and senior levels." />
+
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui'] },
+          colors: {
+            primary: {50:'#EEF2FF',100:'#E0EAFF',200:'#C7D4FF',300:'#9EB6FF',400:'#6E90FF',500:'#3B6CFF',600:'#1D4ED8',700:'#1E40AF',800:'#1E3A8A',900:'#172554'}
+          },
+          boxShadow: { soft: '0 10px 30px rgba(2,6,23,0.08)' }
+        }
+      }
+    };
+  </script>
+  <style>:root{color-scheme:light dark;} html{font-feature-settings:"ss01" on,"cv01" on;}</style>
+
+</head>
+<body class="bg-white text-slate-800 dark:bg-slate-950 dark:text-slate-100">
+
+  <header class="sticky top-0 z-50 backdrop-blur bg-white/70 dark:bg-slate-950/60 border-b border-slate-900/5 dark:border-white/5">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex h-16 items-center justify-between">
+        <a href="index.html" class="flex items-center gap-3 group">
+          <div class="relative w-9 h-9 grid place-items-center rounded-xl bg-gradient-to-br from-primary-500 to-indigo-600 text-white shadow-soft">
+            <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M4 16l8-12 8 12-8 4-8-4z"/>
+            </svg>
+          </div>
+          <div class="leading-tight">
+            <div class="font-extrabold tracking-tight text-lg">Suvix IT</div>
+            <div class="text-xs text-slate-500 dark:text-slate-400">Keep IT Simple</div>
+          </div>
+        </a>
+        <nav class="hidden md:flex items-center gap-8 text-sm">
+          <a href="index.html#products" class="hover:text-primary-600 dark:hover:text-primary-300">Products</a>
+          <a href="index.html#pricing" class="hover:text-primary-600 dark:hover:text-primary-300">Pricing</a>
+          <a href="index.html#about" class="hover:text-primary-600 dark:hover:text-primary-300">About</a>
+          <a href="careers.html" class="text-primary-600 dark:text-primary-300 font-semibold">Careers</a>
+          <a href="index.html#contact" class="hover:text-primary-600 dark:hover:text-primary-300">Contact</a>
+        </nav>
+        <div class="flex items-center gap-3">
+          <a href="index.html#pricing" class="hidden sm:inline-flex items-center rounded-xl border border-slate-200 dark:border-white/10 px-3 py-2 text-sm font-medium hover:bg-slate-50 dark:hover:bg-white/5">View Plans</a>
+          <button id="themeToggle" class="inline-flex items-center rounded-xl border border-slate-200 dark:border-white/10 px-2.5 py-2" title="Toggle theme" aria-label="Toggle theme">
+            <svg id="sun" class="w-5 h-5 hidden dark:inline" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+            <svg id="moon" class="w-5 h-5 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+          <button id="mobileMenuBtn" class="md:hidden inline-flex items-center rounded-xl border border-slate-200 dark:border-white/10 p-2" aria-label="Open menu">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-900/5 dark:border-white/5">
+      <div class="px-4 py-3 flex flex-col gap-2 text-sm">
+        <a href="index.html#products" class="py-2">Products</a>
+        <a href="index.html#pricing" class="py-2">Pricing</a>
+        <a href="index.html#about" class="py-2">About</a>
+        <a href="careers.html" class="py-2 text-primary-600 dark:text-primary-300 font-semibold">Careers</a>
+        <a href="index.html#contact" class="py-2">Contact</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="bg-gradient-to-b from-primary-50 to-transparent dark:from-indigo-950/40 py-16">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <nav class="text-sm text-slate-500"><a href="index.html" class="hover:underline">Home</a> / <span class="text-slate-700 dark:text-slate-300">Careers</span></nav>
+      <div class="mt-6 grid lg:grid-cols-[1.2fr_1fr] gap-12 items-start">
+        <div>
+          <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-tight">Build modern products that keep IT simple.</h1>
+          <p class="mt-5 text-lg text-slate-600 dark:text-slate-300 max-w-2xl">Join a nimble product team shipping tools for traders and customer-facing teams across India. We combine craftsmanship with pragmatism and believe great products are built by people who care about impact.</p>
+          <div class="mt-8 grid sm:grid-cols-3 gap-4 text-sm">
+            <div class="rounded-xl border border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-900/60 p-4">
+              <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Way of working</div>
+              <div class="mt-2 font-semibold">Remote-first, async-friendly</div>
+            </div>
+            <div class="rounded-xl border border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-900/60 p-4">
+              <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Focus</div>
+              <div class="mt-2 font-semibold">Small teams, big outcomes</div>
+            </div>
+            <div class="rounded-xl border border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-900/60 p-4">
+              <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Benefits</div>
+              <div class="mt-2 font-semibold">Health cover, learning stipend</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 space-y-4">
+          <h2 class="text-xl font-semibold">What we value</h2>
+          <ul class="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+            <li class="flex gap-3"><span class="mt-1 inline-flex w-1.5 h-1.5 rounded-full bg-primary-500"></span><span>Outcome-oriented builders who ship iteratively and take ownership.</span></li>
+            <li class="flex gap-3"><span class="mt-1 inline-flex w-1.5 h-1.5 rounded-full bg-primary-500"></span><span>Clean, well-tested code and thoughtful UI decisions.</span></li>
+            <li class="flex gap-3"><span class="mt-1 inline-flex w-1.5 h-1.5 rounded-full bg-primary-500"></span><span>Empathy for customers and teammates, especially in a remote setup.</span></li>
+          </ul>
+          <a href="#open-roles" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-5 py-3 text-sm font-medium shadow-soft hover:brightness-110">See open roles ↓</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="grid md:grid-cols-2 gap-8 items-start">
+        <div>
+          <h2 class="text-2xl font-bold">Why engineers enjoy working here</h2>
+          <p class="mt-4 text-sm text-slate-600 dark:text-slate-300">We run lean, trust experts, and keep meetings light. Engineers partner closely with product and design from idea to launch.</p>
+          <ul class="mt-6 space-y-4 text-sm text-slate-600 dark:text-slate-300">
+            <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Modern stack.</strong> ASP.NET Core microservices, React frontends, automated CI/CD, and observability baked in.</span></li>
+            <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Learning budget.</strong> Annual allowance for courses, books, or certifications aligned to your growth path.</span></li>
+            <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Wellness first.</strong> Comprehensive health insurance for you and dependents plus no-questions-asked mental health days.</span></li>
+          </ul>
+        </div>
+        <div class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6">
+          <h3 class="text-lg font-semibold">How we hire</h3>
+          <ol class="mt-4 space-y-4 text-sm text-slate-600 dark:text-slate-300 list-decimal list-inside">
+            <li>Share your resume, GitHub or project links, and a short note on what excites you.</li>
+            <li>Initial video chat to learn about your goals and discuss the role.</li>
+            <li>Collaborative technical exercise focused on real-world scenarios.</li>
+            <li>Meet future teammates to explore culture fit and ways of working.</li>
+            <li>Receive offer with transparent compensation and onboarding plan.</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="open-roles" class="py-16 bg-slate-50 dark:bg-slate-900/40 border-y border-slate-900/5 dark:border-white/5">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center max-w-2xl mx-auto">
+        <h2 class="text-3xl font-extrabold tracking-tight">Open engineering roles</h2>
+        <p class="mt-3 text-slate-600 dark:text-slate-300">We&apos;re hiring across junior (0–1 year) and senior (4–5 years) experience bands for ASP.NET Core and React development.</p>
+      </div>
+      <div class="mt-10 grid gap-6 lg:grid-cols-2">
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
+          <div>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Backend</div>
+            <h3 class="mt-2 text-xl font-semibold">ASP.NET Core Developer — Junior</h3>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">0–1 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India)</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Full-time</span>
+          </div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Help build APIs powering our FlowCRM and StoxEdge products. You&apos;ll learn directly from senior engineers and ship to production from week one.</p>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Develop RESTful services in ASP.NET Core with clean architecture patterns.</li>
+              <li>Collaborate with frontend engineers to design API contracts.</li>
+              <li>Write unit tests and contribute to automated deployment pipelines.</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Solid knowledge of C#, .NET fundamentals, and SQL basics.</li>
+              <li>Exposure to Git, Postman, or similar developer tooling.</li>
+              <li>An eagerness to learn, ask questions, and improve every sprint.</li>
+            </ul>
+          </div>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20ASP.NET%20Core%20Developer%20%E2%80%94%20Junior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
+          <div>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Backend</div>
+            <h3 class="mt-2 text-xl font-semibold">ASP.NET Core Developer — Senior</h3>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">4–5 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India) • Hybrid optional</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Lead initiatives</span>
+          </div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Own critical services that handle scale, reliability, and security. Partner with product to influence roadmaps and mentor the next wave of developers.</p>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Design and implement distributed services, background jobs, and integrations.</li>
+              <li>Champion code quality through reviews, architecture discussions, and pairing.</li>
+              <li>Improve observability, reliability, and security across our backend stack.</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Expertise in ASP.NET Core, microservices, and SQL/NoSQL datastores.</li>
+              <li>Experience with Azure, AWS, or equivalent cloud environments.</li>
+              <li>A track record of mentoring engineers and leading delivery end-to-end.</li>
+            </ul>
+          </div>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20ASP.NET%20Core%20Developer%20%E2%80%94%20Senior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
+          <div>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Frontend</div>
+            <h3 class="mt-2 text-xl font-semibold">React Developer — Junior</h3>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">0–1 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India)</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Full-time</span>
+          </div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Create delightful user interfaces for dashboards and mobile-responsive experiences. Ship features alongside design and product in quick cycles.</p>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Build reusable components with React, TypeScript, and Tailwind CSS.</li>
+              <li>Integrate REST and GraphQL APIs, ensuring accessibility and performance.</li>
+              <li>Participate in design reviews and QA to polish every release.</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Understanding of modern JavaScript/TypeScript, React hooks, and state management.</li>
+              <li>Familiarity with responsive design and testing tools such as Jest or Cypress.</li>
+              <li>A portfolio or GitHub repo showcasing UI work or side projects.</li>
+            </ul>
+          </div>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20React%20Developer%20%E2%80%94%20Junior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
+          <div>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Frontend</div>
+            <h3 class="mt-2 text-xl font-semibold">React Developer — Senior</h3>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">4–5 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India) • Hybrid optional</span>
+            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Lead initiatives</span>
+          </div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Shape the frontend architecture across products, drive best practices, and mentor a growing team of React developers.</p>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Architect design systems, state management strategies, and performance budgets.</li>
+              <li>Collaborate with backend leads to define contracts and observability standards.</li>
+              <li>Coach developers through code reviews, pairing sessions, and roadmap planning.</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
+            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
+              <li>Deep expertise with React, TypeScript, build tooling, and performance optimization.</li>
+              <li>Experience integrating design systems and collaborating with product designers.</li>
+              <li>Ability to define front-end standards and guide teams through change.</li>
+            </ul>
+          </div>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20React%20Developer%20%E2%80%94%20Senior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h2 class="text-2xl font-bold">Ready to build what&apos;s next?</h2>
+      <p class="mt-4 text-sm text-slate-600 dark:text-slate-300">Email <a href="mailto:careers@suvixit.com" class="text-primary-600 dark:text-primary-300 font-medium hover:underline">careers@suvixit.com</a> with your resume and any work samples. We review every application and respond within five business days.</p>
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <a href="mailto:careers@suvixit.com" class="inline-flex items-center rounded-xl bg-primary-600 text-white px-5 py-3 text-sm font-medium shadow-soft hover:brightness-110">Send your profile</a>
+        <a href="https://cal.com/" target="_blank" rel="noopener" class="inline-flex items-center rounded-xl border border-slate-200 dark:border-white/10 px-5 py-3 text-sm font-medium hover:bg-slate-50 dark:hover:bg-white/5">Book intro call</a>
+      </div>
+    </div>
+  </section>
+
+  <footer class="py-10 border-t border-slate-900/5 dark:border-white/5">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
+        <div class="flex items-center gap-3">
+          <div class="w-8 h-8 grid place-items-center rounded-lg bg-gradient-to-br from-primary-600 to-indigo-600 text-white">
+            <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 16l8-12 8 12-8 4-8-4z"/></svg>
+          </div>
+          <div>
+            <div class="font-bold">Suvix IT</div>
+            <div class="text-xs text-slate-500">© <span id="y"></span> All rights reserved.</div>
+          </div>
+        </div>
+        <div class="text-sm text-slate-500 flex gap-6">
+          <a href="#" class="hover:text-primary-600 dark:hover:text-primary-300">Terms</a>
+          <a href="#" class="hover:text-primary-600 dark:hover:text-primary-300">Privacy</a>
+          <a href="index.html#contact" class="hover:text-primary-600 dark:hover:text-primary-300">Support</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script>
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) document.documentElement.classList.add('dark');
+    document.getElementById('themeToggle')?.addEventListener('click', () => {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+    document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
+      document.getElementById('mobileMenu').classList.toggle('hidden');
+    });
+    document.getElementById('y').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/flowcrm.html
+++ b/flowcrm.html
@@ -46,6 +46,7 @@
           <a href="index.html#products" class="hover:text-primary-600 dark:hover:text-primary-300">Products</a>
           <a href="index.html#pricing" class="hover:text-primary-600 dark:hover:text-primary-300">Pricing</a>
           <a href="index.html#about" class="hover:text-primary-600 dark:hover:text-primary-300">About</a>
+          <a href="careers.html" class="hover:text-primary-600 dark:hover:text-primary-300">Careers</a>
           <a href="index.html#contact" class="hover:text-primary-600 dark:hover:text-primary-300">Contact</a>
         </nav>
         <div class="flex items-center gap-3">
@@ -65,6 +66,7 @@
         <a href="index.html#products" class="py-2">Products</a>
         <a href="index.html#pricing" class="py-2">Pricing</a>
         <a href="index.html#about" class="py-2">About</a>
+        <a href="careers.html" class="py-2">Careers</a>
         <a href="index.html#contact" class="py-2">Contact</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
           <a href="index.html#products" class="hover:text-primary-600 dark:hover:text-primary-300">Products</a>
           <a href="index.html#pricing" class="hover:text-primary-600 dark:hover:text-primary-300">Pricing</a>
           <a href="index.html#about" class="hover:text-primary-600 dark:hover:text-primary-300">About</a>
+          <a href="careers.html" class="hover:text-primary-600 dark:hover:text-primary-300">Careers</a>
           <a href="index.html#contact" class="hover:text-primary-600 dark:hover:text-primary-300">Contact</a>
         </nav>
         <div class="flex items-center gap-3">
@@ -65,6 +66,7 @@
         <a href="index.html#products" class="py-2">Products</a>
         <a href="index.html#pricing" class="py-2">Pricing</a>
         <a href="index.html#about" class="py-2">About</a>
+        <a href="careers.html" class="py-2">Careers</a>
         <a href="index.html#contact" class="py-2">Contact</a>
       </div>
     </div>

--- a/stoxedge.html
+++ b/stoxedge.html
@@ -46,6 +46,7 @@
           <a href="index.html#products" class="hover:text-primary-600 dark:hover:text-primary-300">Products</a>
           <a href="index.html#pricing" class="hover:text-primary-600 dark:hover:text-primary-300">Pricing</a>
           <a href="index.html#about" class="hover:text-primary-600 dark:hover:text-primary-300">About</a>
+          <a href="careers.html" class="hover:text-primary-600 dark:hover:text-primary-300">Careers</a>
           <a href="index.html#contact" class="hover:text-primary-600 dark:hover:text-primary-300">Contact</a>
         </nav>
         <div class="flex items-center gap-3">
@@ -65,6 +66,7 @@
         <a href="index.html#products" class="py-2">Products</a>
         <a href="index.html#pricing" class="py-2">Pricing</a>
         <a href="index.html#about" class="py-2">About</a>
+        <a href="careers.html" class="py-2">Careers</a>
         <a href="index.html#contact" class="py-2">Contact</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated careers page that highlights company values, hiring process, and how to apply
- list junior (0–1 yr) and senior (4–5 yr) openings for ASP.NET Core and React developers with responsibilities and key skills
- link the new page from the navigation menus across existing product pages

## Testing
- not run (static site content)


------
https://chatgpt.com/codex/tasks/task_e_68d220f9f16483319462cc8fa5819bad