### PR TITLE
Refresh careers page with AI focus

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -78,7 +78,7 @@
       <div class="mt-6 grid lg:grid-cols-[1.2fr_1fr] gap-12 items-start">
         <div>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-tight">Build modern products that keep IT simple.</h1>
-          <p class="mt-5 text-lg text-slate-600 dark:text-slate-300 max-w-2xl">Join a nimble product team shipping tools for traders and customer-facing teams across India. We combine craftsmanship with pragmatism and work across ASP.NET, React, Python, and Artificial Intelligence technologies because great products are built by people who care about impact.</p>
+          <p class="mt-5 text-lg text-slate-600 dark:text-slate-300 max-w-2xl">Join a nimble product team shipping tools for traders and customer-facing teams across India. We combine craftsmanship with pragmatism across ASP.NET, React, Python, and AI ecosystems like OpenAI, LangChain, and TensorFlow because great products are built by people who care about impact.</p>
           <div class="mt-8 grid sm:grid-cols-3 gap-4 text-sm">
             <div class="rounded-xl border border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-900/60 p-4">
               <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Way of working</div>
@@ -90,7 +90,7 @@
             </div>
             <div class="rounded-xl border border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-900/60 p-4">
               <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Benefits</div>
-              <div class="mt-2 font-semibold">Health cover, learning stipend</div>
+              <div class="mt-2 font-semibold">Learning stipend, home office support</div>
             </div>
           </div>
         </div>
@@ -116,7 +116,7 @@
           <ul class="mt-6 space-y-4 text-sm text-slate-600 dark:text-slate-300">
             <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Modern stack.</strong> ASP.NET Core microservices, React frontends, Python data layers, AI-powered services, automated CI/CD, and observability baked in.</span></li>
             <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Learning budget.</strong> Annual allowance for courses, books, or certifications aligned to your growth path.</span></li>
-            <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Wellness first.</strong> Comprehensive health insurance for you and dependents plus no-questions-asked mental health days.</span></li>
+            <li class="flex gap-3"><span class="mt-2 inline-flex w-2 h-2 rounded-full bg-primary-500"></span><span><strong>Autonomy built-in.</strong> Plan your schedule, collaborate asynchronously, and enjoy quiet focus time without micro-management.</span></li>
           </ul>
         </div>
         <div class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6">
@@ -133,131 +133,127 @@
     </div>
   </section>
 
+  <section class="py-16 bg-slate-100/60 dark:bg-slate-900/40 border-y border-slate-900/5 dark:border-white/5">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-3xl font-extrabold tracking-tight">AI technologies we build with</h2>
+        <p class="mt-3 text-slate-600 dark:text-slate-300">Intelligent experiences are at the core of our products. We combine trusted engineering practices with modern AI platforms to deliver reliable automation.</p>
+      </div>
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white/80 dark:bg-slate-900 shadow-soft p-6 text-left">
+          <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">OpenAI / ChatGPT-style LLMs</h3>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Core for natural language processing, reasoning, and coding help.</p>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Used in chatbots, content generation, and knowledge assistants.</p>
+        </article>
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white/80 dark:bg-slate-900 shadow-soft p-6 text-left">
+          <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Machine Learning Frameworks (TensorFlow / PyTorch / Scikit-learn)</h3>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Essential for training, fine-tuning, and deploying custom AI models.</p>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Backbone for predictive analytics, computer vision, and industry-specific solutions.</p>
+        </article>
+        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white/80 dark:bg-slate-900 shadow-soft p-6 text-left">
+          <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">LangChain &amp; Agent Frameworks</h3>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Used to build AI agents that connect LLMs with real-world data, APIs, and business workflows.</p>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Critical for automation and integrating AI into enterprise apps.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <section id="open-roles" class="py-16 bg-slate-50 dark:bg-slate-900/40 border-y border-slate-900/5 dark:border-white/5">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center max-w-2xl mx-auto">
         <h2 class="text-3xl font-extrabold tracking-tight">Open engineering roles</h2>
-        <p class="mt-3 text-slate-600 dark:text-slate-300">We&apos;re hiring across junior (0–1 year) and senior (4–5 years) experience bands for ASP.NET Core, React, Python, and Artificial Intelligence technologies.</p>
+        <p class="mt-3 text-slate-600 dark:text-slate-300">We&apos;re hiring product-minded engineers who move fluidly between backend services, front-end experiences, and AI-powered automation.</p>
       </div>
-      <div class="mt-10 grid gap-6 lg:grid-cols-2">
+      <div class="mt-10 grid gap-6 lg:grid-cols-3">
         <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
           <div>
-            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Backend</div>
-            <h3 class="mt-2 text-xl font-semibold">ASP.NET Core Developer — Junior</h3>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Product</div>
+            <h3 class="mt-2 text-xl font-semibold">Product Engineer — Early Career</h3>
           </div>
           <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">0–1 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">0–2 years experience</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India)</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Full-time</span>
           </div>
-          <p class="text-sm text-slate-600 dark:text-slate-300">Help build APIs powering our FlowCRM and StoxEdge products. You&apos;ll learn directly from senior engineers and ship to production from week one.</p>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Ship product slices end-to-end with support from mentors. You&apos;ll touch APIs, web interfaces, and AI features that improve customer workflows.</p>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Develop RESTful services in ASP.NET Core with clean architecture patterns.</li>
-              <li>Collaborate with frontend engineers to design API contracts.</li>
-              <li>Write unit tests and contribute to automated deployment pipelines.</li>
+              <li>Build features across ASP.NET Core services, React frontends, and Python automation.</li>
+              <li>Collaborate with design and product to release measurable improvements quickly.</li>
+              <li>Experiment with OpenAI-powered assistants to elevate user experiences.</li>
             </ul>
           </div>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Solid knowledge of C#, .NET fundamentals, and SQL basics.</li>
-              <li>Exposure to Git, Postman, or similar developer tooling.</li>
-              <li>An eagerness to learn, ask questions, and improve every sprint.</li>
+              <li>Solid grounding in C#, JavaScript/TypeScript, or Python fundamentals.</li>
+              <li>Comfort with Git, API clients, and component libraries.</li>
+              <li>A growth mindset and curiosity to learn from pair-programming and feedback.</li>
             </ul>
           </div>
-          <a href="mailto:careers@suvixit.com?subject=Application%3A%20ASP.NET%20Core%20Developer%20%E2%80%94%20Junior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20Product%20Engineer%20%E2%80%94%20Early%20Career" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
         </article>
 
         <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
           <div>
-            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Backend</div>
-            <h3 class="mt-2 text-xl font-semibold">ASP.NET Core Developer — Senior</h3>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Product</div>
+            <h3 class="mt-2 text-xl font-semibold">Product Engineer — Senior</h3>
           </div>
           <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
             <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">4–5 years experience</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India) • Hybrid optional</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Lead initiatives</span>
           </div>
-          <p class="text-sm text-slate-600 dark:text-slate-300">Own critical services that handle scale, reliability, and security. Partner with product to influence roadmaps and mentor the next wave of developers.</p>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Own ambitious roadmaps, connect customer insights to architecture decisions, and mentor teammates across the stack.</p>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Design and implement distributed services, background jobs, and integrations.</li>
-              <li>Champion code quality through reviews, architecture discussions, and pairing.</li>
-              <li>Improve observability, reliability, and security across our backend stack.</li>
+              <li>Design resilient services, polished interfaces, and AI-enabled workflows end-to-end.</li>
+              <li>Champion engineering excellence through reviews, observability, and CI/CD improvements.</li>
+              <li>Coach engineers and partner with product to sequence impactful releases.</li>
             </ul>
           </div>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Expertise in ASP.NET Core, microservices, and SQL/NoSQL datastores.</li>
-              <li>Experience with Azure, AWS, or equivalent cloud environments.</li>
-              <li>A track record of mentoring engineers and leading delivery end-to-end.</li>
+              <li>Depth building distributed systems and modern web experiences.</li>
+              <li>Experience with cloud infrastructure, testing strategies, and release automation.</li>
+              <li>A track record of mentoring engineers and aligning cross-functional teams.</li>
             </ul>
           </div>
-          <a href="mailto:careers@suvixit.com?subject=Application%3A%20ASP.NET%20Core%20Developer%20%E2%80%94%20Senior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20Product%20Engineer%20%E2%80%94%20Senior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
         </article>
 
         <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
           <div>
-            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Frontend</div>
-            <h3 class="mt-2 text-xl font-semibold">React Developer — Junior</h3>
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • AI</div>
+            <h3 class="mt-2 text-xl font-semibold">AI Platform Engineer</h3>
           </div>
           <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">0–1 years experience</span>
+            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">3–6 years experience</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India)</span>
             <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Full-time</span>
           </div>
-          <p class="text-sm text-slate-600 dark:text-slate-300">Create delightful user interfaces for dashboards and mobile-responsive experiences. Ship features alongside design and product in quick cycles.</p>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Build the intelligence layer behind our products by orchestrating LLMs, data pipelines, and evaluation systems that customers can trust.</p>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Build reusable components with React, TypeScript, and Tailwind CSS.</li>
-              <li>Integrate REST and GraphQL APIs, ensuring accessibility and performance.</li>
-              <li>Participate in design reviews and QA to polish every release.</li>
+              <li>Design guardrailed experiences with OpenAI and ChatGPT-style models for production use cases.</li>
+              <li>Train, fine-tune, and evaluate models using TensorFlow, PyTorch, or Scikit-learn pipelines.</li>
+              <li>Build LangChain-powered agents that connect LLMs to data stores, APIs, and business workflows.</li>
             </ul>
           </div>
           <div>
             <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
             <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Understanding of modern JavaScript/TypeScript, React hooks, and state management.</li>
-              <li>Familiarity with responsive design and testing tools such as Jest or Cypress.</li>
-              <li>A portfolio or GitHub repo showcasing UI work or side projects.</li>
+              <li>Hands-on experience with GPT-style LLMs, prompt engineering, and evaluation tooling.</li>
+              <li>Proficiency in deploying ML systems with modern MLOps practices.</li>
+              <li>Background integrating AI into customer-facing products and measuring impact.</li>
             </ul>
           </div>
-          <a href="mailto:careers@suvixit.com?subject=Application%3A%20React%20Developer%20%E2%80%94%20Junior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
-        </article>
-
-        <article class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 shadow-soft p-6 flex flex-col gap-5">
-          <div>
-            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Engineering • Frontend</div>
-            <h3 class="mt-2 text-xl font-semibold">React Developer — Senior</h3>
-          </div>
-          <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-200 px-2.5 py-1 font-medium">4–5 years experience</span>
-            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Remote (India) • Hybrid optional</span>
-            <span class="inline-flex items-center rounded-full bg-slate-100 dark:bg-white/10 px-2.5 py-1 font-medium">Lead initiatives</span>
-          </div>
-          <p class="text-sm text-slate-600 dark:text-slate-300">Shape the frontend architecture across products, drive best practices, and mentor a growing team of React developers.</p>
-          <div>
-            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">What you&apos;ll do</h4>
-            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Architect design systems, state management strategies, and performance budgets.</li>
-              <li>Collaborate with backend leads to define contracts and observability standards.</li>
-              <li>Coach developers through code reviews, pairing sessions, and roadmap planning.</li>
-            </ul>
-          </div>
-          <div>
-            <h4 class="text-sm font-semibold text-slate-700 dark:text-slate-200">You&apos;ll thrive if you have</h4>
-            <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc list-inside">
-              <li>Deep expertise with React, TypeScript, build tooling, and performance optimization.</li>
-              <li>Experience integrating design systems and collaborating with product designers.</li>
-              <li>Ability to define front-end standards and guide teams through change.</li>
-            </ul>
-          </div>
-          <a href="mailto:careers@suvixit.com?subject=Application%3A%20React%20Developer%20%E2%80%94%20Senior" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
+          <a href="mailto:careers@suvixit.com?subject=Application%3A%20AI%20Platform%20Engineer" class="inline-flex items-center justify-center rounded-xl bg-primary-600 text-white px-4 py-2 text-sm font-medium hover:brightness-110">Apply via email</a>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- highlight the hero messaging with references to OpenAI, LangChain, and TensorFlow while updating benefits copy
- add a dedicated "AI technologies we build with" section that covers LLMs, ML frameworks, and LangChain agent tooling
- streamline the open roles into product-focused positions and an AI platform role without stack-specific duplication

## Testing
- No automated tests (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d2262b702083318b59a7d6718cd894