### PR TITLE
Add gold value logo for StoxEdge

### DIFF
--- a/assets/stoxedge-value-logo.svg
+++ b/assets/stoxedge-value-logo.svg
@@ -1,0 +1,28 @@
+<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="valueBase" x1="18" y1="10" x2="58" y2="62" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#78350F" />
+      <stop offset="1" stop-color="#312E81" />
+    </linearGradient>
+    <radialGradient id="coinGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(36 32) rotate(90) scale(30)">
+      <stop offset="0" stop-color="#FDE68A" stop-opacity="0.7" />
+      <stop offset="1" stop-color="#FDE68A" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="coinFace" x1="20" y1="16" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FACC15" />
+      <stop offset="1" stop-color="#D97706" />
+    </linearGradient>
+    <linearGradient id="coinRing" x1="24" y1="22" x2="48" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FEF3C7" />
+      <stop offset="1" stop-color="#B45309" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="60" height="60" rx="18" fill="url(#valueBase)" />
+  <circle cx="36" cy="34" r="24" fill="url(#coinGlow)" />
+  <circle cx="36" cy="36" r="22" fill="url(#coinFace)" />
+  <circle cx="36" cy="36" r="16" fill="url(#coinRing)" opacity="0.85" />
+  <circle cx="36" cy="36" r="12.5" fill="#FEFCE8" opacity="0.88" />
+  <path d="M30.5 28.5H44M30.5 34.5H40.5M33.5 28.5C36.5 31 35.5 36.5 30.5 38.5L42 38.5C39.5 40.5 37 43.5 36 45.5" stroke="#B45309" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M48.5 24L50.5 28L54.5 30L50.5 32L48.5 36L46.5 32L42.5 30L46.5 28L48.5 24Z" fill="#FEF3C7" opacity="0.9" />
+  <path d="M24 48C27 50.5 31 52 36 52C41 52 45 50.5 48 48" stroke="#FBBF24" stroke-width="2" stroke-linecap="round" opacity="0.65" />
+</svg>


### PR DESCRIPTION
## Summary
- add a gold-toned StoxEdge value badge SVG featuring a rupee motif, coin shading, and sparkle highlight to represent monetary value

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d34e5760a88331aa6fba224555b787