### PR TITLE
Add ASP.NET Core API for subscriptions and demo requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+.vs/
+*.user
+*.swp
+.idea/

--- a/README.md
+++ b/README.md
@@ -19,3 +19,25 @@ Example:
 - Update pricing in `index.html` as needed.
 - Replace Terms/Privacy links.
 - Add your domain, favicon, and analytics.
+
+## Backend API
+An ASP.NET Core Web API is available in the `SuvixIT.Api` project. It stores newsletter subscriptions, demo requests, and email configuration using PostgreSQL.
+
+### Prerequisites
+- .NET 7 SDK
+- PostgreSQL database (update `ConnectionStrings:DefaultConnection` in `SuvixIT.Api/appsettings.json`).
+
+### Database setup
+Apply Entity Framework Core migrations (create one if this is a new database) or run `dotnet ef database update` after generating migrations.
+
+### Running the API
+```
+dotnet restore SuvixIT.Api/SuvixIT.Api.csproj
+dotnet run --project SuvixIT.Api/SuvixIT.Api.csproj
+```
+Swagger UI will be available at `https://localhost:7189/swagger` in development.
+
+### Key endpoints
+- `POST /api/subscriptions` — Persist a new subscription.
+- `POST /api/demorequests` — Create a demo request and send an email using the stored configuration.
+- `GET/PUT /api/admin/email-configuration` — Manage SMTP settings for outbound notifications.

--- a/SuvixIT.Api/Controllers/AdminController.cs
+++ b/SuvixIT.Api/Controllers/AdminController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Services;
+
+namespace SuvixIT.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AdminController : ControllerBase
+{
+    private readonly IEmailConfigurationService _configurationService;
+
+    public AdminController(IEmailConfigurationService configurationService)
+    {
+        _configurationService = configurationService;
+    }
+
+    [HttpGet("email-configuration")]
+    public async Task<ActionResult<EmailConfigurationViewModel>> GetEmailConfiguration(CancellationToken cancellationToken)
+    {
+        var config = await _configurationService.GetConfigurationAsync(cancellationToken);
+        if (config is null)
+        {
+            return NotFound();
+        }
+
+        return config;
+    }
+
+    [HttpPut("email-configuration")]
+    public async Task<IActionResult> UpdateEmailConfiguration([FromBody] EmailConfigurationDto dto, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        await _configurationService.UpsertConfigurationAsync(dto, cancellationToken);
+        return NoContent();
+    }
+}

--- a/SuvixIT.Api/Controllers/DemoRequestsController.cs
+++ b/SuvixIT.Api/Controllers/DemoRequestsController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+using SuvixIT.Api.Services;
+
+namespace SuvixIT.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DemoRequestsController : ControllerBase
+{
+    private readonly IDemoRequestService _demoRequestService;
+
+    public DemoRequestsController(IDemoRequestService demoRequestService)
+    {
+        _demoRequestService = demoRequestService;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DemoRequest>> SubmitDemoRequest([FromBody] DemoRequestCreateDto dto, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var request = await _demoRequestService.CreateRequestAsync(dto, cancellationToken);
+
+        return CreatedAtAction(nameof(GetDemoRequest), new { id = request.Id }, request);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<DemoRequest>> GetDemoRequest(Guid id, CancellationToken cancellationToken)
+    {
+        var request = await _demoRequestService.GetRequestAsync(id, cancellationToken);
+        if (request is null)
+        {
+            return NotFound();
+        }
+
+        return request;
+    }
+}

--- a/SuvixIT.Api/Controllers/SubscriptionsController.cs
+++ b/SuvixIT.Api/Controllers/SubscriptionsController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SuvixIT.Api.Data;
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SubscriptionsController : ControllerBase
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public SubscriptionsController(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Subscription>> CreateSubscription([FromBody] SubscriptionCreateDto dto, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var existing = await _dbContext.Subscriptions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Email == dto.Email, cancellationToken);
+
+        if (existing is not null)
+        {
+            return Conflict($"Subscription already exists for {dto.Email}.");
+        }
+
+        var subscription = new Subscription
+        {
+            Email = dto.Email,
+            FullName = dto.FullName,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _dbContext.Subscriptions.AddAsync(subscription, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetSubscription), new { id = subscription.Id }, subscription);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Subscription>> GetSubscription(Guid id, CancellationToken cancellationToken)
+    {
+        var subscription = await _dbContext.Subscriptions.AsNoTracking().FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        if (subscription is null)
+        {
+            return NotFound();
+        }
+
+        return subscription;
+    }
+}

--- a/SuvixIT.Api/DTOs/DemoRequestCreateDto.cs
+++ b/SuvixIT.Api/DTOs/DemoRequestCreateDto.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SuvixIT.Api.DTOs;
+
+public class DemoRequestCreateDto
+{
+    [Required]
+    [MaxLength(200)]
+    public string CompanyName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(200)]
+    public string ContactName { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string ContactEmail { get; set; } = string.Empty;
+
+    [MaxLength(2000)]
+    public string? Message { get; set; }
+}

--- a/SuvixIT.Api/DTOs/EmailConfigurationDto.cs
+++ b/SuvixIT.Api/DTOs/EmailConfigurationDto.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SuvixIT.Api.DTOs;
+
+public class EmailConfigurationDto
+{
+    [Required]
+    [MaxLength(200)]
+    public string SmtpHost { get; set; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int SmtpPort { get; set; } = 25;
+
+    [MaxLength(200)]
+    public string Username { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string SenderAddress { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string RecipientAddress { get; set; } = string.Empty;
+
+    public bool UseSsl { get; set; } = true;
+}

--- a/SuvixIT.Api/DTOs/EmailConfigurationViewModel.cs
+++ b/SuvixIT.Api/DTOs/EmailConfigurationViewModel.cs
@@ -1,0 +1,11 @@
+namespace SuvixIT.Api.DTOs;
+
+public class EmailConfigurationViewModel
+{
+    public string SmtpHost { get; set; } = string.Empty;
+    public int SmtpPort { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string SenderAddress { get; set; } = string.Empty;
+    public string RecipientAddress { get; set; } = string.Empty;
+    public bool UseSsl { get; set; }
+}

--- a/SuvixIT.Api/DTOs/SubscriptionCreateDto.cs
+++ b/SuvixIT.Api/DTOs/SubscriptionCreateDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SuvixIT.Api.DTOs;
+
+public class SubscriptionCreateDto
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? FullName { get; set; }
+}

--- a/SuvixIT.Api/Data/ApplicationDbContext.cs
+++ b/SuvixIT.Api/Data/ApplicationDbContext.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Data;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Subscription> Subscriptions => Set<Subscription>();
+    public DbSet<DemoRequest> DemoRequests => Set<DemoRequest>();
+    public DbSet<EmailConfiguration> EmailConfigurations => Set<EmailConfiguration>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Subscription>()
+            .HasIndex(s => s.Email)
+            .IsUnique();
+
+        modelBuilder.Entity<EmailConfiguration>()
+            .HasData(new EmailConfiguration
+            {
+                Id = 1,
+                SmtpHost = string.Empty,
+                SmtpPort = 25,
+                Username = string.Empty,
+                Password = string.Empty,
+                SenderAddress = string.Empty,
+                RecipientAddress = string.Empty,
+                UseSsl = true
+            });
+    }
+}

--- a/SuvixIT.Api/Models/DemoRequest.cs
+++ b/SuvixIT.Api/Models/DemoRequest.cs
@@ -1,0 +1,11 @@
+namespace SuvixIT.Api.Models;
+
+public class DemoRequest
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string CompanyName { get; set; } = string.Empty;
+    public string ContactName { get; set; } = string.Empty;
+    public string ContactEmail { get; set; } = string.Empty;
+    public string? Message { get; set; }
+    public DateTime RequestedAt { get; set; } = DateTime.UtcNow;
+}

--- a/SuvixIT.Api/Models/EmailConfiguration.cs
+++ b/SuvixIT.Api/Models/EmailConfiguration.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SuvixIT.Api.Models;
+
+public class EmailConfiguration
+{
+    [Key]
+    public int Id { get; set; }
+
+    [MaxLength(200)]
+    public string SmtpHost { get; set; } = string.Empty;
+
+    public int SmtpPort { get; set; } = 25;
+
+    [MaxLength(200)]
+    public string Username { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string Password { get; set; } = string.Empty;
+
+    [EmailAddress]
+    [MaxLength(200)]
+    public string SenderAddress { get; set; } = string.Empty;
+
+    [EmailAddress]
+    [MaxLength(200)]
+    public string RecipientAddress { get; set; } = string.Empty;
+
+    public bool UseSsl { get; set; } = true;
+}

--- a/SuvixIT.Api/Models/Subscription.cs
+++ b/SuvixIT.Api/Models/Subscription.cs
@@ -1,0 +1,9 @@
+namespace SuvixIT.Api.Models;
+
+public class Subscription
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Email { get; set; } = string.Empty;
+    public string? FullName { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/SuvixIT.Api/Program.cs
+++ b/SuvixIT.Api/Program.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using SuvixIT.Api.Data;
+using SuvixIT.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("Connection string 'DefaultConnection' is not configured.");
+}
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseNpgsql(connectionString));
+
+builder.Services.AddScoped<IEmailConfigurationService, EmailConfigurationService>();
+builder.Services.AddScoped<IEmailSender, SmtpEmailSender>();
+builder.Services.AddScoped<IDemoRequestService, DemoRequestService>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/SuvixIT.Api/Properties/launchSettings.json
+++ b/SuvixIT.Api/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "SuvixIT.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7189;http://localhost:5189",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/SuvixIT.Api/Services/DemoRequestService.cs
+++ b/SuvixIT.Api/Services/DemoRequestService.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using SuvixIT.Api.Data;
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public class DemoRequestService : IDemoRequestService
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly IEmailSender _emailSender;
+
+    public DemoRequestService(ApplicationDbContext dbContext, IEmailSender emailSender)
+    {
+        _dbContext = dbContext;
+        _emailSender = emailSender;
+    }
+
+    public async Task<DemoRequest> CreateRequestAsync(DemoRequestCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        var request = new DemoRequest
+        {
+            CompanyName = dto.CompanyName,
+            ContactName = dto.ContactName,
+            ContactEmail = dto.ContactEmail,
+            Message = dto.Message,
+            RequestedAt = DateTime.UtcNow
+        };
+
+        await _dbContext.DemoRequests.AddAsync(request, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var configuration = await _dbContext.EmailConfigurations.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+        if (configuration is not null)
+        {
+            await _emailSender.SendDemoRequestNotificationAsync(configuration, request, cancellationToken);
+        }
+
+        return request;
+    }
+
+    public Task<DemoRequest?> GetRequestAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.DemoRequests.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+}

--- a/SuvixIT.Api/Services/EmailConfigurationService.cs
+++ b/SuvixIT.Api/Services/EmailConfigurationService.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using SuvixIT.Api.Data;
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public class EmailConfigurationService : IEmailConfigurationService
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EmailConfigurationService(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<EmailConfigurationViewModel?> GetConfigurationAsync(CancellationToken cancellationToken = default)
+    {
+        var config = await _dbContext.EmailConfigurations.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+
+        if (config is null)
+        {
+            return null;
+        }
+
+        return new EmailConfigurationViewModel
+        {
+            SmtpHost = config.SmtpHost,
+            SmtpPort = config.SmtpPort,
+            Username = config.Username,
+            SenderAddress = config.SenderAddress,
+            RecipientAddress = config.RecipientAddress,
+            UseSsl = config.UseSsl
+        };
+    }
+
+    public async Task<EmailConfiguration> UpsertConfigurationAsync(EmailConfigurationDto dto, CancellationToken cancellationToken = default)
+    {
+        var config = await _dbContext.EmailConfigurations.FirstOrDefaultAsync(cancellationToken);
+
+        if (config is null)
+        {
+            config = new EmailConfiguration();
+            _dbContext.EmailConfigurations.Add(config);
+        }
+
+        config.SmtpHost = dto.SmtpHost;
+        config.SmtpPort = dto.SmtpPort;
+        config.Username = dto.Username;
+        config.Password = dto.Password;
+        config.SenderAddress = dto.SenderAddress;
+        config.RecipientAddress = dto.RecipientAddress;
+        config.UseSsl = dto.UseSsl;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return config;
+    }
+}

--- a/SuvixIT.Api/Services/IDemoRequestService.cs
+++ b/SuvixIT.Api/Services/IDemoRequestService.cs
@@ -1,0 +1,10 @@
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public interface IDemoRequestService
+{
+    Task<DemoRequest> CreateRequestAsync(DemoRequestCreateDto dto, CancellationToken cancellationToken = default);
+    Task<DemoRequest?> GetRequestAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/SuvixIT.Api/Services/IEmailConfigurationService.cs
+++ b/SuvixIT.Api/Services/IEmailConfigurationService.cs
@@ -1,0 +1,10 @@
+using SuvixIT.Api.DTOs;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public interface IEmailConfigurationService
+{
+    Task<EmailConfigurationViewModel?> GetConfigurationAsync(CancellationToken cancellationToken = default);
+    Task<EmailConfiguration> UpsertConfigurationAsync(EmailConfigurationDto dto, CancellationToken cancellationToken = default);
+}

--- a/SuvixIT.Api/Services/IEmailSender.cs
+++ b/SuvixIT.Api/Services/IEmailSender.cs
@@ -1,0 +1,8 @@
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public interface IEmailSender
+{
+    Task SendDemoRequestNotificationAsync(EmailConfiguration configuration, DemoRequest request, CancellationToken cancellationToken = default);
+}

--- a/SuvixIT.Api/Services/SmtpEmailSender.cs
+++ b/SuvixIT.Api/Services/SmtpEmailSender.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Mail;
+using System.Text;
+using SuvixIT.Api.Models;
+
+namespace SuvixIT.Api.Services;
+
+public class SmtpEmailSender : IEmailSender
+{
+    public async Task SendDemoRequestNotificationAsync(EmailConfiguration configuration, DemoRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(configuration.SmtpHost) || string.IsNullOrWhiteSpace(configuration.RecipientAddress))
+        {
+            return;
+        }
+
+        using var client = new SmtpClient(configuration.SmtpHost, configuration.SmtpPort)
+        {
+            EnableSsl = configuration.UseSsl,
+            Credentials = string.IsNullOrWhiteSpace(configuration.Username)
+                ? CredentialCache.DefaultNetworkCredentials
+                : new NetworkCredential(configuration.Username, configuration.Password)
+        };
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(string.IsNullOrWhiteSpace(configuration.SenderAddress)
+                ? configuration.RecipientAddress
+                : configuration.SenderAddress),
+            Subject = $"New demo request from {request.CompanyName}",
+            Body = BuildBody(request),
+            IsBodyHtml = false
+        };
+
+        message.To.Add(configuration.RecipientAddress);
+
+        using var registration = cancellationToken.Register(() => client.SendAsyncCancel());
+        await client.SendMailAsync(message, cancellationToken);
+    }
+
+    private static string BuildBody(DemoRequest request)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Company: {request.CompanyName}");
+        builder.AppendLine($"Contact: {request.ContactName}");
+        builder.AppendLine($"Email: {request.ContactEmail}");
+        builder.AppendLine($"Requested At (UTC): {request.RequestedAt:u}");
+
+        if (!string.IsNullOrWhiteSpace(request.Message))
+        {
+            builder.AppendLine();
+            builder.AppendLine("Message:");
+            builder.AppendLine(request.Message);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/SuvixIT.Api/SuvixIT.Api.csproj
+++ b/SuvixIT.Api/SuvixIT.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/SuvixIT.Api/appsettings.Development.json
+++ b/SuvixIT.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Debug"
+    }
+  }
+}

--- a/SuvixIT.Api/appsettings.json
+++ b/SuvixIT.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=suvixit;Username=postgres;Password=postgres"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new SuvixIT.Api ASP.NET Core project configured for PostgreSQL persistence
- implement subscription, demo request, and admin email configuration endpoints with DTOs and services
- document API usage and project requirements in the repository README

## Testing
- not run (dotnet CLI not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690199953afc833199ed997dbdc060f4